### PR TITLE
Add redirect to /logout for github.com

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -82,6 +82,7 @@ var leakSocialMediaAccounts = function(callback) {
     }, {
         domain: "https://github.com",
         redirect: "/login?return_to=https%3A%2F%2Fgithub.com%2Ffavicon.ico%3Fid%3D1",
+        redirectLogout: "/logout",
         name: "Github"
     }, {
         domain: "https://medium.com",

--- a/index.html
+++ b/index.html
@@ -323,8 +323,9 @@
     function displayResult(network, loggedIn) {
         var id = loggedIn ? 'loggedIn' : 'notLoggedIn';
         var favicon = faviconUri(network);
-        var url = network.domain + network.redirect;
-        var el = '<a target="_blank" href="' + url + '" target="_blank" class=network><img src=' + favicon + '><span>' + network.name + '</span></a>';
+        var logoutLink = network.domain + network.redirectLogout;
+        
+        var el = '<a target="_blank" href="' + logoutLink + '" target="_blank" class=network><img src=' + favicon + '><span>' + network.name + '</span></a>';
         if (loggedIn && isFirstLoggedIn) {
             isFirstLoggedIn = false;
             document.getElementById(id).innerHTML = el;


### PR DESCRIPTION
I think, some users will want to logout from their accounts via socialmedia-leak, once they are reminded where they are still logged in.

So I made a prototype for a new feature:
Now, you can click on the Github Button and you will be redirected to the `/logout`. Before, I used to get redirected to some github icon. 
I did this by adding a `redirectLogout` field to the github item in `var platforms` in demo.js .

If you like the idea, I would try to update the rest of the items in `var platforms` analogously.
